### PR TITLE
Add typos linter to the CLI, fix errors

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,6 +18,7 @@ jobs:
         run: yarn add standard
       - name: Run Standard
         run: yarn standard html/index.js
+      - uses: crate-ci/typos@master
   css-linter:
     name: CSS linter (stylelint)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The release version of the parser is based on the claim format version. The patc
 Users can write notes or feedback about their test run in the HTML parser. 
 This displayed results and feedback can be downloaded as a static HTML page to be shared. 
 Users can also save their feedback as a json file for later use. 
-To load a file containing previouly entered feedback, users can
+To load a file containing previously entered feedback, users can
 upload their `feedback.json` file to the parser HTML page via the `Upload Feedback File` button.  Alternatively,
 users can convert their `feedback.json` to `feedback.js` and place it in the same folder as the result.html page.
 The feedback will be loaded automatically.

--- a/html/index.js
+++ b/html/index.js
@@ -352,7 +352,7 @@ function generateTestcaseSingleResultElement (currentTestResult, tableName, id, 
   // Now we should populate the item contents
   commonTestTextContent += '<div id="' + itemid + '" class="accordion-collapse collapse" aria-labelledby="' + headingid + '">'
   commonTestTextContent += '<div class="accordion-body" >'
-  // Inside the accordion, 1 table with the following colummns. header below:
+  // Inside the accordion, 1 table with the following columns header below:
   commonTestTextContent += '<h1>Results</h1>'
   commonTestTextContent += '<div class="table-responsive">'
   commonTestTextContent += '<table id="myTable-' + currentTestResult.testID.id + '" class="table table-bordered"><thead><tr>'
@@ -924,7 +924,7 @@ function expand (data, event) {
   }
 }
 
-// event listerner for collapsing items
+// event listener for collapsing items
 function collapse (data, event) {
   event.preventDefault()
   event.stopPropagation()
@@ -1005,7 +1005,7 @@ function updateProgressBar (value) {
   }
 }
 
-// Initalize the progress bar to 0%
+// Initialize the progress bar to 0%
 function initProgressBar () {
   const progressBar = document.querySelector('.progress-bar')
   progressBar.style.width = '0%'


### PR DESCRIPTION
Github CLI linters should use a single checkout. Will be fixed in a separated PR.