### PR TITLE
Remove yarn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: npm
-    directory: /html
-    schedule:
-      interval: daily
-  - package-ecosystem: yarn
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
Dependabot doesn't like the `yarn` specific package-ecosystem reference.